### PR TITLE
adding nginx-svc

### DIFF
--- a/nginx-svc/README.md
+++ b/nginx-svc/README.md
@@ -1,0 +1,8 @@
+# Simple deployment for Kubernetes
+Deployment manifest for nginx with a service type load balancer exposed on port TCP/80.
+The purpose of this manifest is to test any Kubernetes cluster with the creation of a load balancer
+
+To deploy the manifest, run the command:
+```
+kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual-nodes/main/nginx-svc/nginx.yaml
+```

--- a/nginx-svc/nginx.yaml
+++ b/nginx-svc/nginx.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: nginx


### PR DESCRIPTION
I want to add this manifest to deploy nginx with a service type load balancer.
There are plenty of nginx deployment files on internet, but none have a service type load balancer included.
This deployment will allow users to quickly test an app to validate the cluster is configured correctly.