### PR TITLE
support for security contexts

### DIFF
--- a/ingress-nginx/README.md
+++ b/ingress-nginx/README.md
@@ -10,14 +10,14 @@ kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual
 ## Change Log
 The following lines are commented out from the ingress-nginx deployment manifest version 1.9.3: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
 - lines 488 to 493
-#          allowPrivilegeEscalation: true
-#          capabilities:
-#            add:
-#            - NET_BIND_SERVICE
-#            drop:
-#            - ALL
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
 - lines 551 and 600
-#        fsGroup: 2000
+        fsGroup: 2000
 
 Previously, the following lines are commented out from the ingress-nginx deployment manifest version 1.7.0: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
 - lines 484 to 490

--- a/ingress-nginx/README.md
+++ b/ingress-nginx/README.md
@@ -10,14 +10,18 @@ kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual
 ## Change Log
 The following lines are commented out from the ingress-nginx deployment manifest version 1.9.3: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
 - lines 488 to 493
+```
           allowPrivilegeEscalation: true
           capabilities:
             add:
             - NET_BIND_SERVICE
             drop:
             - ALL
+```
 - lines 551 and 600
+```
         fsGroup: 2000
+```
 
 Previously, the following lines are commented out from the ingress-nginx deployment manifest version 1.7.0: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
 - lines 484 to 490

--- a/ingress-nginx/README.md
+++ b/ingress-nginx/README.md
@@ -1,11 +1,27 @@
 # ingress-nginx deployment on OKE Virtual Nodes
 Deployment file for ingress-nginx on OKE Virtual Nodes.
-This is a modified version from the upstream deployment file at https://github.com/kubernetes/ingress-nginx.
+This is a modified version from the upstream deployment file at https://github.com/kubernetes/ingress-nginx of ingress-nginx version 1.9.3.
+
+Deploy Nginx Ingress Controller in a cluster with virtual nodes using:
+```
+kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual-nodes/main/ingress-nginx/deploy.yaml
+```
 
 ## Change Log
-The following lines are commented out from https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
-- 484 to 490
-- 542
-- 547 to 549
-- 591
-- 596 to 598
+The following lines are commented out from the ingress-nginx deployment manifest version 1.9.3: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
+- lines 488 to 493
+#          allowPrivilegeEscalation: true
+#          capabilities:
+#            add:
+#            - NET_BIND_SERVICE
+#            drop:
+#            - ALL
+- lines 551 and 600
+#        fsGroup: 2000
+
+Previously, the following lines are commented out from the ingress-nginx deployment manifest version 1.7.0: https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/cloud/deploy.yaml.
+- lines 484 to 490
+- line 542
+- lines 547 to 549
+- line 591
+- lines 596 to 598

--- a/ingress-nginx/deploy.yaml
+++ b/ingress-nginx/deploy.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx
   namespace: ingress-nginx
 ---
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission
   namespace: ingress-nginx
 ---
@@ -39,7 +39,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx
   namespace: ingress-nginx
 rules:
@@ -129,7 +129,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission
   namespace: ingress-nginx
 rules:
@@ -148,7 +148,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx
 rules:
 - apiGroups:
@@ -230,7 +230,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission
 rules:
 - apiGroups:
@@ -249,7 +249,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx
   namespace: ingress-nginx
 roleRef:
@@ -269,7 +269,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission
   namespace: ingress-nginx
 roleRef:
@@ -288,7 +288,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -307,7 +307,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -320,7 +320,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  allow-snippet-annotations: "true"
+  allow-snippet-annotations: "false"
 kind: ConfigMap
 metadata:
   labels:
@@ -328,7 +328,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-controller
   namespace: ingress-nginx
 ---
@@ -340,7 +340,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -373,7 +373,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-controller-admission
   namespace: ingress-nginx
 spec:
@@ -396,7 +396,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
@@ -407,6 +407,10 @@ spec:
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/name: ingress-nginx
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -414,7 +418,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.7.0
+        app.kubernetes.io/version: 1.9.3
     spec:
       containers:
       - args:
@@ -438,7 +442,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LD_PRELOAD
           value: /usr/local/lib/libmimalloc.so
-        image: registry.k8s.io/ingress-nginx/controller:v1.7.0@sha256:7612338342a1e7b8090bef78f2a04fffcadd548ccaabe8a47bf7758ff549a5f7
+        image: registry.k8s.io/ingress-nginx/controller:v1.9.3@sha256:8fd21d59428507671ce0fb47f818b1d859c92d2ad07bb7c947268d433030ba98
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -487,7 +491,7 @@ spec:
 #            - NET_BIND_SERVICE
 #            drop:
 #            - ALL
-#          runAsUser: 101
+          runAsUser: 101
         volumeMounts:
         - mountPath: /usr/local/certificates/
           name: webhook-cert
@@ -510,7 +514,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission-create
   namespace: ingress-nginx
 spec:
@@ -521,7 +525,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.7.0
+        app.kubernetes.io/version: 1.9.3
       name: ingress-nginx-admission-create
     spec:
       containers:
@@ -535,18 +539,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794@sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0@sha256:a7943503b45d552785aa3b5e457f169a5661fb94d82b8a3373bcd9ebaf9aac80
         imagePullPolicy: IfNotPresent
         name: create
         securityContext:
-#          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: false
       nodeSelector:
         kubernetes.io/os: linux
       restartPolicy: OnFailure
       securityContext:
 #        fsGroup: 2000
-#        runAsNonRoot: true
-#        runAsUser: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
       serviceAccountName: ingress-nginx-admission
 ---
 apiVersion: batch/v1
@@ -557,7 +561,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission-patch
   namespace: ingress-nginx
 spec:
@@ -568,7 +572,7 @@ spec:
         app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
-        app.kubernetes.io/version: 1.7.0
+        app.kubernetes.io/version: 1.9.3
       name: ingress-nginx-admission-patch
     spec:
       containers:
@@ -584,18 +588,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794@sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0@sha256:a7943503b45d552785aa3b5e457f169a5661fb94d82b8a3373bcd9ebaf9aac80
         imagePullPolicy: IfNotPresent
         name: patch
         securityContext:
-#          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: false
       nodeSelector:
         kubernetes.io/os: linux
       restartPolicy: OnFailure
       securityContext:
 #        fsGroup: 2000
-#        runAsNonRoot: true
-#        runAsUser: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
       serviceAccountName: ingress-nginx-admission
 ---
 apiVersion: networking.k8s.io/v1
@@ -606,10 +610,33 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.9.3
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: admission-webhook
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+  policyTypes:
+  - Ingress
+  - Egress
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -619,7 +646,7 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.7.0
+    app.kubernetes.io/version: 1.9.3
   name: ingress-nginx-admission
 webhooks:
 - admissionReviewVersions:

--- a/kubernetes-dashboard/README.md
+++ b/kubernetes-dashboard/README.md
@@ -24,13 +24,13 @@ Now access Dashboard at http://localhost:8001/api/v1/namespaces/kubernetes-dashb
 ## Change Log
 The following lines are commented out from the Kubernetes Dashboard deployment manifest version 2.7.0: https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
 - lines 211 to 217
-#          livenessProbe:
-#            httpGet:
-#              scheme: HTTPS
-#              path: /
-#              port: 8443
-#            initialDelaySeconds: 30
-#            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
 
 Previously, the following lines are commented out from the Kubernetes Dashboard deployment manifest version 2.7.0.
 - lines 211 to 222

--- a/kubernetes-dashboard/README.md
+++ b/kubernetes-dashboard/README.md
@@ -24,6 +24,7 @@ Now access Dashboard at http://localhost:8001/api/v1/namespaces/kubernetes-dashb
 ## Change Log
 The following lines are commented out from the Kubernetes Dashboard deployment manifest version 2.7.0: https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
 - lines 211 to 217
+```
           livenessProbe:
             httpGet:
               scheme: HTTPS
@@ -31,6 +32,7 @@ The following lines are commented out from the Kubernetes Dashboard deployment m
               port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 30
+```
 
 Previously, the following lines are commented out from the Kubernetes Dashboard deployment manifest version 2.7.0.
 - lines 211 to 222

--- a/kubernetes-dashboard/README.md
+++ b/kubernetes-dashboard/README.md
@@ -2,11 +2,6 @@
 Deployment file for Kubernetes Dashboard on OKE Virtual Nodes.
 This is a modified version from the upstream deployment file at https://github.com/kubernetes/dashboard.
 
-## Change Log
-The following lines are commented out from https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml.
-- 211 to 222
-- 292 to 296
-
 ## Getting started
 Deploy the dashboard in a cluster with virtual nodes using:
 ```
@@ -25,3 +20,18 @@ Start a proxy on your workstation to access the dashboard:
 kubectl proxy
 ```
 Now access Dashboard at http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
+
+## Change Log
+The following lines are commented out from the Kubernetes Dashboard deployment manifest version 2.7.0: https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
+- lines 211 to 217
+#          livenessProbe:
+#            httpGet:
+#              scheme: HTTPS
+#              path: /
+#              port: 8443
+#            initialDelaySeconds: 30
+#            timeoutSeconds: 30
+
+Previously, the following lines are commented out from the Kubernetes Dashboard deployment manifest version 2.7.0.
+- lines 211 to 222
+- lines 292 to 296

--- a/kubernetes-dashboard/recommended.yaml
+++ b/kubernetes-dashboard/recommended.yaml
@@ -215,11 +215,11 @@ spec:
 #              port: 8443
 #            initialDelaySeconds: 30
 #            timeoutSeconds: 30
-#          securityContext:
-#            allowPrivilegeEscalation: false
-#            readOnlyRootFilesystem: true
-#            runAsUser: 1001
-#            runAsGroup: 2001
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       volumes:
         - name: kubernetes-dashboard-certs
           secret:
@@ -289,11 +289,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-volume
-#          securityContext:
-#            allowPrivilegeEscalation: false
-#            readOnlyRootFilesystem: true
-#            runAsUser: 1001
-#            runAsGroup: 2001
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
         "kubernetes.io/os": linux

--- a/logging-sidecar/README.md
+++ b/logging-sidecar/README.md
@@ -1,6 +1,12 @@
 # Kubernetes pod with a sidecar for logging 
 The purpose of this manifest is to show how to add a sidecar to pod to send logs on a flat file to a persistent location such as Opensearch.
 
+Customize the ConfigMap in date-logging.yaml with
+- a value for `host`, the IP address of your Opensearch server
+- a value for `port`, the port of your Opensearch server (9200 by default)
+- a value for `HTTP_User`, the username of of your Opensearch server
+- a value for `HTTP_Passwd`, the password of of your Opensearch server
+
 To deploy the manifest, run the command:
 ```
 kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual-nodes/main/date-logging.yaml

--- a/logging-sidecar/date-logging.yaml
+++ b/logging-sidecar/date-logging.yaml
@@ -18,8 +18,8 @@ data:
         host 10.0.21.195
         port 9200
         tls On
-        HTTP_User elastic
-        HTTP_Passwd wNKhoWtnh9_Emm9
+        HTTP_User XXXXX
+        HTTP_Passwd XXXXX
         Index fluent-bit
         Suppress_Type_Name On
 ---

--- a/logging-sidecar/date-logging.yaml
+++ b/logging-sidecar/date-logging.yaml
@@ -15,7 +15,7 @@ data:
     [OUTPUT]
         name  opensearch
         match *
-        host 10.0.21.195
+        host X.X.X.X
         port 9200
         tls On
         HTTP_User XXXXX

--- a/metrics-server/README.md
+++ b/metrics-server/README.md
@@ -10,22 +10,22 @@ kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual
 ## Change Log
 The following lines are commented out from the metrics-server deployment manifest v0.6.4: https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 - lines 142 to 148
-#        livenessProbe:
-#          failureThreshold: 3
-#          httpGet:
-#            path: /livez
-#            port: https
-#            scheme: HTTPS
-#          periodSeconds: 10
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
 - lines 154 to 161
-#        readinessProbe:
-#          failureThreshold: 3
-#          httpGet:
-#            path: /readyz
-#            port: https
-#            scheme: HTTPS
-#          initialDelaySeconds: 20
-#          periodSeconds: 10
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+          periodSeconds: 10
 
 Previously, the following lines were commented out from the metrics-server deployment manifest v0.6.3.
 - lines 142 to 148

--- a/metrics-server/README.md
+++ b/metrics-server/README.md
@@ -2,8 +2,32 @@
 Deployment file for metrics-server on OKE Virtual Nodes.
 This is a modified version from the upstream deployment file at https://github.com/kubernetes-sigs/metrics-server.
 
+Deploy metrics server in a cluster with virtual nodes using:
+```
+kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual-nodes/main/metrics-server/components.yml
+```
+
 ## Change Log
-The following lines are commented out from https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.3/deploy/static/provider/cloud/deploy.yaml.
-- 142 to 148
-- 154 to 161
-- 167 to 170
+The following lines are commented out from the metrics-server deployment manifest v0.6.4: https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+- lines 142 to 148
+#        livenessProbe:
+#          failureThreshold: 3
+#          httpGet:
+#            path: /livez
+#            port: https
+#            scheme: HTTPS
+#          periodSeconds: 10
+- lines 154 to 161
+#        readinessProbe:
+#          failureThreshold: 3
+#          httpGet:
+#            path: /readyz
+#            port: https
+#            scheme: HTTPS
+#          initialDelaySeconds: 20
+#          periodSeconds: 10
+
+Previously, the following lines were commented out from the metrics-server deployment manifest v0.6.3.
+- lines 142 to 148
+- lines 154 to 161
+- lines 167 to 170

--- a/metrics-server/README.md
+++ b/metrics-server/README.md
@@ -10,6 +10,7 @@ kubectl apply -f https://raw.githubusercontent.com/oracle-devrel/oci-oke-virtual
 ## Change Log
 The following lines are commented out from the metrics-server deployment manifest v0.6.4: https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 - lines 142 to 148
+```
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17,7 +18,9 @@ The following lines are commented out from the metrics-server deployment manifes
             port: https
             scheme: HTTPS
           periodSeconds: 10
+```
 - lines 154 to 161
+```
         readinessProbe:
           failureThreshold: 3
           httpGet:
@@ -26,6 +29,7 @@ The following lines are commented out from the metrics-server deployment manifes
             scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10
+```
 
 Previously, the following lines were commented out from the metrics-server deployment manifest v0.6.3.
 - lines 142 to 148

--- a/metrics-server/components.yml
+++ b/metrics-server/components.yml
@@ -137,7 +137,7 @@ spec:
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
 #        livenessProbe:
 #          failureThreshold: 3
@@ -164,10 +164,10 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
-#          allowPrivilegeEscalation: false
-#          readOnlyRootFilesystem: true
-#          runAsNonRoot: true
-#          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - mountPath: /tmp
           name: tmp-dir


### PR DESCRIPTION
OKE Virtual Nodes now support Kubernetes security contexts. Ref: https://docs.oracle.com/en-us/iaas/releasenotes/changes/11f7afad-51d9-451a-b666-76b1ea5e8945/
The deployment manifests for Ingress-nginx, metrics-server, and Kubernetes dashboard are updated to include the Kubernetes security contexts from the upstream deployment manifests.