### PR TITLE
metric-resolution update

### DIFF
--- a/metrics-server/README.md
+++ b/metrics-server/README.md
@@ -31,6 +31,11 @@ The following lines are commented out from the metrics-server deployment manifes
           periodSeconds: 10
 ```
 
+In addtion, the parameter metric-resolutionis set to 60s on line 139. OKE Virtual Nodes support a minimum metric resolution of 60 seconds.
+```
+        - --metric-resolution=60s
+```
+
 Previously, the following lines were commented out from the metrics-server deployment manifest v0.6.3.
 - lines 142 to 148
 - lines 154 to 161

--- a/metrics-server/components.yml
+++ b/metrics-server/components.yml
@@ -136,7 +136,7 @@ spec:
         - --secure-port=4443
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
-        - --metric-resolution=15s
+        - --metric-resolution=60s
         image: registry.k8s.io/metrics-server/metrics-server:v0.6.4
         imagePullPolicy: IfNotPresent
 #        livenessProbe:


### PR DESCRIPTION
I updated the metric-resolution in metrics-server because 60 sec is currently the minimum value supported